### PR TITLE
update sentry version

### DIFF
--- a/patches/api/0001-Add-Sentry.patch
+++ b/patches/api/0001-Add-Sentry.patch
@@ -12,7 +12,7 @@ index b71c38473c3a9fddbb26dcc06df0c1adcdc871f6..305b1233e13d37d1599912e70d3eeb80
      apiAndDocs("net.kyori:adventure-text-serializer-plain")
      api("org.apache.logging.log4j:log4j-api:2.17.1")
      api("org.slf4j:slf4j-api:1.8.0-beta4")
-+    api("io.sentry:sentry:5.4.0") // Pufferfish
++    api("io.sentry:sentry:5.6.2") // Pufferfish
  
      implementation("org.ow2.asm:asm:9.2")
      implementation("org.ow2.asm:asm-commons:9.2")


### PR DESCRIPTION
This PR aims to update the version of the Sentry dependency, however I haven’t tested it, though the dependency has only been bumped by 2 minor versions and 2 patch versions so I doubt any breaking changes have been implemented.