### PR TITLE
Update airplaneRef in gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,4 +9,4 @@ group=gg.pufferfish.pufferfish
 version=1.17.1-R0.1-SNAPSHOT
 mcVersion=1.17.1
 packageVersion=1_17_1_R1
-airplaneRef=c253f344943cf3639695a7b38913ee90f36022c7
+airplaneRef=af3563c98bdd8b27123e3a656de261ed96652b3e


### PR DESCRIPTION
Paper replaced third party repos with their own in the latest 1.17 commit. This included yarn which was removed from QuiltMC's maven repo, which is necessary to generate mappings.