### PR TITLE
Prevent CPU busy waiting by waiting for async tasks

### DIFF
--- a/patches/server/0002-Pufferfish-Utils.patch
+++ b/patches/server/0002-Pufferfish-Utils.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Pufferfish Utils
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/util/misc/AreaMap.java b/src/main/java/com/destroystokyo/paper/util/misc/AreaMap.java
-index c89f6986eda5a132a948732ea1b6923370685317..a69c13e20040c1561d9c2d4d89ec7d4e635134fc 100644
+index 41b9405d6759d865e0d14dd4f95163e9690e967d..091b1ae822e1c0517e59572e7a9bda11e998c0ee 100644
 --- a/src/main/java/com/destroystokyo/paper/util/misc/AreaMap.java
 +++ b/src/main/java/com/destroystokyo/paper/util/misc/AreaMap.java
 @@ -26,7 +26,7 @@ public abstract class AreaMap<E> {
@@ -64,60 +64,95 @@ index 0000000000000000000000000000000000000000..53f2df00c6809618a9ee3d2ea72e85e8
 +}
 diff --git a/src/main/java/gg/pufferfish/pufferfish/util/AsyncExecutor.java b/src/main/java/gg/pufferfish/pufferfish/util/AsyncExecutor.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..9d6dc2c80945bec9bea74714c657c7a2e0bdde9e
+index 0000000000000000000000000000000000000000..3ea4db15b78dab21379f3dedc0d514dadd83ad32
 --- /dev/null
 +++ b/src/main/java/gg/pufferfish/pufferfish/util/AsyncExecutor.java
-@@ -0,0 +1,51 @@
+@@ -0,0 +1,86 @@
 +package gg.pufferfish.pufferfish.util;
 +
 +import com.google.common.collect.Queues;
 +import gg.pufferfish.pufferfish.PufferfishLogger;
 +import java.util.Queue;
-+import java.util.concurrent.locks.LockSupport;
-+import java.util.function.BooleanSupplier;
++import java.util.concurrent.locks.Condition;
++import java.util.concurrent.locks.Lock;
++import java.util.concurrent.locks.ReentrantLock;
 +import java.util.logging.Level;
 +
++/**
++ * <p>
++ * A simple executor that has its own thread to perform tasks on.
++ * This executor is currently only used to move some calculations required for mob spawning off the main thread
++ * ({@link net.minecraft.server.MinecraftServer#mobSpawnExecutor}).
++ * </p>
++ * <p>
++ * It uses a non-blocking {@link java.util.concurrent.ConcurrentLinkedQueue} to store its tasks.
++ * </p>
++ */
 +public class AsyncExecutor implements Runnable {
-+	
++
 +	private Queue<Runnable> jobs = Queues.newConcurrentLinkedQueue();
 +	private final Thread thread;
-+	private final BooleanSupplier shouldRun;
++	// Use tryLock() instead of lock() on this lock to avoid blocking the (main) thread,
++	// because any thread will hold this lock for much shorter than the time it takes to do a context switch (~5 micros)
++	private final Lock waitLock = new ReentrantLock();
++	private final Condition waitCondition = waitLock.newCondition();
 +	private volatile boolean killswitch = false;
-+	
-+	public AsyncExecutor(String threadName, BooleanSupplier shouldRun) {
++
++	public AsyncExecutor(String threadName) {
 +		this.thread = new Thread(this, threadName);
-+		this.shouldRun = shouldRun;
 +	}
-+	
++
++	private void signalWaiting() {
++		while (!waitLock.tryLock()) {}
++		try {
++			if (killswitch || !jobs.isEmpty()) {
++				waitCondition.signal();
++			}
++		} finally {
++			waitLock.unlock();
++		}
++	}
++
 +	public void start() {
 +		thread.start();
 +	}
-+	
++
 +	public void kill() {
 +		killswitch = true;
++		signalWaiting();
 +	}
-+	
++
 +	public void submit(Runnable runnable) {
 +		jobs.offer(runnable);
++		signalWaiting();
 +	}
-+	
++
 +	@Override
 +	public void run() {
 +		while (!killswitch) {
-+			if (shouldRun.getAsBoolean()) {
-+				try {
-+					Runnable runnable;
-+					while ((runnable = jobs.poll()) != null) {
-+						runnable.run();
++			while (!waitLock.tryLock()) {}
++			try {
++				while (!killswitch && jobs.isEmpty()) {
++					try {
++						waitCondition.await();
++					} catch (InterruptedException e) {
++						PufferfishLogger.LOGGER.log(Level.WARNING, e, () -> "Async waiting for tasks was interrupted " + thread.getName());
 +					}
++				}
++			} finally {
++				waitLock.unlock();
++			}
++			Runnable runnable;
++			while ((runnable = jobs.poll()) != null) {
++				try {
++					runnable.run();
 +				} catch (Exception e) {
 +					PufferfishLogger.LOGGER.log(Level.SEVERE, e, () -> "Failed to execute async job for thread " + thread.getName());
 +				}
 +			}
-+			LockSupport.parkNanos("executing tasks", 1000L);
 +		}
 +	}
-+	
++
 +}
 diff --git a/src/main/java/gg/pufferfish/pufferfish/util/AsyncPlayerAreaMap.java b/src/main/java/gg/pufferfish/pufferfish/util/AsyncPlayerAreaMap.java
 new file mode 100644

--- a/patches/server/0009-Optimize-mob-spawning.patch
+++ b/patches/server/0009-Optimize-mob-spawning.patch
@@ -43,7 +43,7 @@ index 62d231ca05039c99c17252847cb850983864e09a..fca3cc322ab396d0865e8082bc673836
 +	
  }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 497e0dc337154ff4d0a7d057768ff5b5b6fda943..b9544ad11fcb9277fa7a3e0842a33da61828e12f 100644
+index 6ba71433f50e7fdfed5e9da273d7163f992b69cf..70cf57e532be110cc5801ec72031d6e5ced53574 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -298,6 +298,8 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -51,12 +51,12 @@ index 497e0dc337154ff4d0a7d057768ff5b5b6fda943..b9544ad11fcb9277fa7a3e0842a33da6
      public volatile boolean abnormalExit = false; // Paper
      public boolean isIteratingOverLevels = false; // Paper
 +    
-+    public gg.pufferfish.pufferfish.util.AsyncExecutor mobSpawnExecutor = new gg.pufferfish.pufferfish.util.AsyncExecutor("MobSpawning", () -> true); // Pufferfish - optimize mob spawning
++    public gg.pufferfish.pufferfish.util.AsyncExecutor mobSpawnExecutor = new gg.pufferfish.pufferfish.util.AsyncExecutor("MobSpawning"); // Pufferfish - optimize mob spawning
  
      public static <S extends MinecraftServer> S spin(Function<Thread, S> serverFactory) {
          AtomicReference<S> atomicreference = new AtomicReference();
 diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-index 6ad8200d6ddfdd9f9e3e0b7e7647bf9661f4bfae..d4efadbc87ee0b6cb8564c57fc9dcbb48367a767 100644
+index 99bbb5b2e5462114cd0802961461abd961301958..5c54a5da7fb50cd97799c5fa280a24d5c6117244 100644
 --- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 @@ -340,6 +340,7 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
@@ -68,7 +68,7 @@ index 6ad8200d6ddfdd9f9e3e0b7e7647bf9661f4bfae..d4efadbc87ee0b6cb8564c57fc9dcbb4
          }
      }
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 5461bac37b6dc0575cccd6656b48b2ef18cfaa04..4078f0bad6e0575e6534798652cecaf96335d979 100644
+index 9ad7c417616e68b1d14a702aca38b2582feb896c..1ee6b8cc232e7aba512b7a4cbdb575e35acd8eb7 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -334,7 +334,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -81,7 +81,7 @@ index 5461bac37b6dc0575cccd6656b48b2ef18cfaa04..4078f0bad6e0575e6534798652cecaf9
          this.playerEntityTrackerTrackMaps = new com.destroystokyo.paper.util.misc.PlayerAreaMap[TRACKING_RANGE_TYPES.length];
          this.entityTrackerTrackRanges = new int[TRACKING_RANGE_TYPES.length];
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 6d1f929eb717f62f0d7ebb9e9b52c3788061e240..9d4329132bb2a1b66fad1a2e8dd17cc87884cb3c 100644
+index be97d38f45046a7f6d2337d879651f04cf9ff825..c2e63457fd85f78e3656d0e88b45c04cee1f610f 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -75,6 +75,9 @@ public class ServerChunkCache extends ChunkSource {


### PR DESCRIPTION
The `AsyncExecutor` used for async mob spawning uses `LockSupport.parkNanos` with an interval of 1 microsecond. Typical context switches can take roughly 5 microseconds, and a microsecond is easily taken up by the necessary code, which involves an expensive concurrent queue CAS call. This causes 1 entire physical CPU core to be constantly running or switching to and away from the AsyncExecutor thread.

Experiment:
* Create a new Pufferfish server from scratch with all settings on default. Set `keep-spawn-loaded` in `paper-world-defaults.yml` to `false` (to make sure the server will have minimal activity from itself).
* On a virtual 6-core 6-thread machine, I measured the CPU usage for 10 minutes:
  | `enable-async-mob-spawning` | CPU usage of server process | Total CPU usage |
  |-|-|-|
  | `false` | 2.1 % | 5.1 % |
  | `true` | 9.3 % | 23.0 % |
* This is as expected if approximately 1 CPU core is constantly busy context switching, and approximately half of that time will be counted as part of the server process, and 100 % / 6 / 2 = 8.3 % (if you run with hyperthreading, for example 4-core 8-thread, the server process CPU usage will be high also, but the difference between server process and total CPU usage should be much smaller because the CPU will prevent context switches)

This pull request fixes the issue: the AsyncExecutor can now optionally (based on the new `shouldWait` field) wait for new tasks to be added instead of parking for a set interval. Results after this commit:
  | `enable-async-mob-spawning` | CPU usage of server process | Total CPU usage |
  |-|-|-|
  | `true` | 2.2 % | 5.4 % |