### PR TITLE
Change simpleyaml group

### DIFF
--- a/patches/server/0003-Pufferfish-Config-and-Command.patch
+++ b/patches/server/0003-Pufferfish-Config-and-Command.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Pufferfish Config and Command
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 9418f84e7f62334f5f7a7310b80ea59f39abfee3..9bbcb198af531a3f95d091ad2138f538e84372e1 100644
+index 9418f84e7f62334f5f7a7310b80ea59f39abfee3..ba4f96f7db637e21a40424ad965717f9e7c4b363 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -48,6 +48,13 @@ dependencies {
@@ -14,7 +14,7 @@ index 9418f84e7f62334f5f7a7310b80ea59f39abfee3..9bbcb198af531a3f95d091ad2138f538
  
 +    // Pufferfish start
 +    implementation("org.yaml:snakeyaml:1.32")
-+    implementation ("me.carleslc.Simple-YAML:Simple-Yaml:1.8.4") {
++    implementation ("com.github.carleslc.Simple-YAML:Simple-Yaml:1.8.4") {
 +        exclude(group="org.yaml", module="snakeyaml")
 +    }
 +    // Pufferfish end


### PR DESCRIPTION
something about the Jitpack setup on this lib is goofed
https://jitpack.io/com/github/carleslc/Simple-YAML/Simple-Yaml/1.8.4/Simple-Yaml-1.8.4.pom exists
https://jitpack.io/me/carleslc/Simple-YAML/Simple-Yaml/1.8.4/Simple-Yaml-1.8.4.pom doesn't
this just allows people to build locally, people with this already installed will be fine. left this as a separate commit so it's easily revertible 
see: [carleslc/](https://github.com/Carleslc/Simple-YAML/issues/77)