### PR TITLE
Disable suffocation optimization for withers

### DIFF
--- a/patches/server/0008-Optimize-suffocation.patch
+++ b/patches/server/0008-Optimize-suffocation.patch
@@ -43,7 +43,7 @@ index e11d7283662834047b2ff81a2fd25a4263792deb..b63b5a3d30e70224d7490d90e99514da
  
              if (!this.level().isClientSide) {
 -                if (this.isInWall()) {
-+                if ((!gg.pufferfish.pufferfish.PufferfishConfig.enableSuffocationOptimization || (tickCount % 10 == 0 && couldPossiblyBeHurt(1.0F))) && this.isInWall()) { // Pufferfish - optimize suffocation
++                if ((!gg.pufferfish.pufferfish.PufferfishConfig.enableSuffocationOptimization || this instanceof net.minecraft.world.entity.boss.wither.WitherBoss || (tickCount % 10 == 0 && couldPossiblyBeHurt(1.0F))) && this.isInWall()) { // Pufferfish - optimize suffocation
                      this.hurt(this.damageSources().inWall(), 1.0F);
                  } else if (flag && !this.level().getWorldBorder().isWithinBounds(this.getBoundingBox())) {
                      double d0 = this.level().getWorldBorder().getDistanceToBorder(this) + this.level().getWorldBorder().getDamageSafeZone();

--- a/patches/server/0008-Optimize-suffocation.patch
+++ b/patches/server/0008-Optimize-suffocation.patch
@@ -35,19 +35,30 @@ index ac56a5ba83184ee7b24b58cc25aa3d5aa953caee..9a8896f51be5028724563cd505478247
 +	
  }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index e11d7283662834047b2ff81a2fd25a4263792deb..b63b5a3d30e70224d7490d90e99514da771bb817 100644
+index e11d7283662834047b2ff81a2fd25a4263792deb..6fa0ec9e2f3384dac5ed4585368f6bf1fc590673 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -414,7 +414,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -393,6 +393,10 @@ public abstract class LivingEntity extends Entity implements Attackable {
+         return Mth.lerp(tickDelta, this.swimAmountO, this.swimAmount);
+     }
+ 
++    public boolean shouldCheckForSuffocation() {
++        return (!gg.pufferfish.pufferfish.PufferfishConfig.enableSuffocationOptimization || (tickCount % 10 == 0 && couldPossiblyBeHurt(1.0F)))
++    }
++
+     @Override
+     public void baseTick() {
+         this.oAttackAnim = this.attackAnim;
+@@ -414,7 +418,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
              boolean flag = this instanceof net.minecraft.world.entity.player.Player;
  
              if (!this.level().isClientSide) {
 -                if (this.isInWall()) {
-+                if ((!gg.pufferfish.pufferfish.PufferfishConfig.enableSuffocationOptimization || this instanceof net.minecraft.world.entity.boss.wither.WitherBoss || (tickCount % 10 == 0 && couldPossiblyBeHurt(1.0F))) && this.isInWall()) { // Pufferfish - optimize suffocation
++                if (shouldCheckForSuffocation() && this.isInWall()) { // Pufferfish - optimize suffocation
                      this.hurt(this.damageSources().inWall(), 1.0F);
                  } else if (flag && !this.level().getWorldBorder().isWithinBounds(this.getBoundingBox())) {
                      double d0 = this.level().getWorldBorder().getDistanceToBorder(this) + this.level().getWorldBorder().getDamageSafeZone();
-@@ -1369,6 +1369,15 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -1369,6 +1373,15 @@ public abstract class LivingEntity extends Entity implements Attackable {
          return this.getHealth() <= 0.0F;
      }
  
@@ -63,3 +74,19 @@ index e11d7283662834047b2ff81a2fd25a4263792deb..b63b5a3d30e70224d7490d90e99514da
      @Override
      public boolean hurt(DamageSource source, float amount) {
          if (this.isInvulnerableTo(source)) {
+diff --git a/src/main/java/net/minecraft/world/entity/boss/wither/WitherBoss.java b/src/main/java/net/minecraft/world/entity/boss/wither/WitherBoss.java
+index 1e07febcf7a3dfb281728cc5e3e4f15dd776d7e0..2ae41d07ff0db1d3f808a7b94831445993128894 100644
+--- a/src/main/java/net/minecraft/world/entity/boss/wither/WitherBoss.java
++++ b/src/main/java/net/minecraft/world/entity/boss/wither/WitherBoss.java
+@@ -150,6 +150,11 @@ public class WitherBoss extends Monster implements PowerableMob, RangedAttackMob
+         this.bossEvent.setName(this.getDisplayName());
+     }
+ 
++    @Override
++    public boolean shouldCheckForSuffocation() {
++        return true;
++    }
++
+     @Override
+     protected SoundEvent getAmbientSound() {
+         return SoundEvents.WITHER_AMBIENT;

--- a/patches/server/0008-Optimize-suffocation.patch
+++ b/patches/server/0008-Optimize-suffocation.patch
@@ -35,21 +35,10 @@ index ac56a5ba83184ee7b24b58cc25aa3d5aa953caee..9a8896f51be5028724563cd505478247
 +	
  }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index e11d7283662834047b2ff81a2fd25a4263792deb..6fa0ec9e2f3384dac5ed4585368f6bf1fc590673 100644
+index e11d7283662834047b2ff81a2fd25a4263792deb..6f0f9037ca1c4c483507a2bb7f6ec86d019c8782 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -393,6 +393,10 @@ public abstract class LivingEntity extends Entity implements Attackable {
-         return Mth.lerp(tickDelta, this.swimAmountO, this.swimAmount);
-     }
- 
-+    public boolean shouldCheckForSuffocation() {
-+        return (!gg.pufferfish.pufferfish.PufferfishConfig.enableSuffocationOptimization || (tickCount % 10 == 0 && couldPossiblyBeHurt(1.0F)))
-+    }
-+
-     @Override
-     public void baseTick() {
-         this.oAttackAnim = this.attackAnim;
-@@ -414,7 +418,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -414,7 +414,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
              boolean flag = this instanceof net.minecraft.world.entity.player.Player;
  
              if (!this.level().isClientSide) {
@@ -58,7 +47,7 @@ index e11d7283662834047b2ff81a2fd25a4263792deb..6fa0ec9e2f3384dac5ed4585368f6bf1
                      this.hurt(this.damageSources().inWall(), 1.0F);
                  } else if (flag && !this.level().getWorldBorder().isWithinBounds(this.getBoundingBox())) {
                      double d0 = this.level().getWorldBorder().getDistanceToBorder(this) + this.level().getWorldBorder().getDamageSafeZone();
-@@ -1369,6 +1373,15 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -1369,6 +1369,19 @@ public abstract class LivingEntity extends Entity implements Attackable {
          return this.getHealth() <= 0.0F;
      }
  
@@ -69,23 +58,29 @@ index e11d7283662834047b2ff81a2fd25a4263792deb..6fa0ec9e2f3384dac5ed4585368f6bf1
 +        }
 +        return true;
 +    }
++
++    public boolean shouldCheckForSuffocation() {
++        return (!gg.pufferfish.pufferfish.PufferfishConfig.enableSuffocationOptimization || (tickCount % 10 == 0 && couldPossiblyBeHurt(1.0F)))
++    }
 +    // Pufferfish end
 +
      @Override
      public boolean hurt(DamageSource source, float amount) {
          if (this.isInvulnerableTo(source)) {
 diff --git a/src/main/java/net/minecraft/world/entity/boss/wither/WitherBoss.java b/src/main/java/net/minecraft/world/entity/boss/wither/WitherBoss.java
-index 1e07febcf7a3dfb281728cc5e3e4f15dd776d7e0..2ae41d07ff0db1d3f808a7b94831445993128894 100644
+index 1e07febcf7a3dfb281728cc5e3e4f15dd776d7e0..c65ab566c6241dd6a44bd11a449ef0c4b2f6dc65 100644
 --- a/src/main/java/net/minecraft/world/entity/boss/wither/WitherBoss.java
 +++ b/src/main/java/net/minecraft/world/entity/boss/wither/WitherBoss.java
-@@ -150,6 +150,11 @@ public class WitherBoss extends Monster implements PowerableMob, RangedAttackMob
+@@ -150,6 +150,13 @@ public class WitherBoss extends Monster implements PowerableMob, RangedAttackMob
          this.bossEvent.setName(this.getDisplayName());
      }
  
++    // Pufferfish start - optimize suffocation
 +    @Override
 +    public boolean shouldCheckForSuffocation() {
 +        return true;
 +    }
++    // Pufferfish end
 +
      @Override
      protected SoundEvent getAmbientSound() {

--- a/patches/server/0011-Strip-raytracing-for-EntityLiving-hasLineOfSight.patch
+++ b/patches/server/0011-Strip-raytracing-for-EntityLiving-hasLineOfSight.patch
@@ -27,10 +27,10 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index b63b5a3d30e70224d7490d90e99514da771bb817..abd31ec72856f5daa63109a09a98b9efc0c86291 100644
+index 6fa0ec9e2f3384dac5ed4585368f6bf1fc590673..0529b93b0ee886b4448c7a6f782b74d8d6b67579 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3660,7 +3660,10 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3664,7 +3664,10 @@ public abstract class LivingEntity extends Entity implements Attackable {
              Vec3 vec3d1 = new Vec3(entity.getX(), entity.getEyeY(), entity.getZ());
  
              // Paper - diff on change - used in CraftLivingEntity#hasLineOfSight(Location) and CraftWorld#lineOfSightExists
@@ -64,7 +64,7 @@ index 0e8746759752b692668886370181aa5db1fd0bb0..58e5ce2afabf480f5dfd9adf43f8fc12
      default BlockHitResult clip(ClipContext raytrace1, BlockPos blockposition) {
              // Paper start - Prevent raytrace from loading chunks
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 147d802d9207e358fdb2d1c7806fc2f634dcfd98..418cfbc84115031651970dee7d9f1c988b64c3a7 100644
+index f39ab10c5b0b8d86b579a5b683491204c51db70b..334f7d5fccff284d7aae982e7a730456773a9935 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -412,6 +412,91 @@ public abstract class Level implements LevelAccessor, AutoCloseable {

--- a/patches/server/0025-Cache-climbing-check-for-activation.patch
+++ b/patches/server/0025-Cache-climbing-check-for-activation.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Cache climbing check for activation
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index abd31ec72856f5daa63109a09a98b9efc0c86291..e9a31314424d9db911cd9806741222397c3072d7 100644
+index 0529b93b0ee886b4448c7a6f782b74d8d6b67579..e645969dc09c441d5309aa811f954d507884ab66 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -142,7 +142,6 @@ import org.bukkit.event.entity.EntityTeleportEvent;
@@ -16,7 +16,7 @@ index abd31ec72856f5daa63109a09a98b9efc0c86291..e9a31314424d9db911cd980674122239
  
  public abstract class LivingEntity extends Entity implements Attackable {
  
-@@ -1974,6 +1973,20 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -1978,6 +1977,20 @@ public abstract class LivingEntity extends Entity implements Attackable {
          return this.lastClimbablePos;
      }
  


### PR DESCRIPTION
Currently, the `enableSuffocationOptimization` usually does a great job reducing entity lag on huge servers.
It reduces the rate of checking for suffocation 10 times (which is collision box calculation and getBlock)

However, it also breaks suffocation based wither cages.
I feel like pufferfish mostly goes against tnt duping, so wither cages seem like the vanilla way to go around block farms.

The description of the optimization says "This should be left enabled or most servers"
So my assumption is if it is supposed to be enabled for most of the servers, then it should have as little practical implications on the gameplay as possible.

The proposed solution would fix suffocation based wither cages on pufferfish with the optimization enabled, while still removing most of the lag from the suffocation check. Given that there are usually only a few withers and thousands of other entities on the server, this option should be the best of both worlds on most of the servers.

Also from a practical standpoint, wither cages are the only useful contraptions that are broken by this patch.
