### PR TITLE
Update Upstream (Paper)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import io.papermc.paperweight.util.constants.PAPERCLIP_CONFIG
 plugins {
     java
     id("com.github.johnrengelman.shadow") version "8.1.1" apply false
-    id("io.papermc.paperweight.patcher") version "1.5.11"
+    id("io.papermc.paperweight.patcher") version "1.5.13"
 }
 
 repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ org.gradle.vfs.watch=false
 group=gg.pufferfish.pufferfish
 version=1.20.4-R0.1-SNAPSHOT
 mcVersion=1.20.4
-paperRef=b6001403e9703cadaa6e8c8558e732b91c3c6d6e
+paperRef=5436d44bf2509ff89129f8790ee4643f09c72871

--- a/patches/api/0001-Add-Sentry.patch
+++ b/patches/api/0001-Add-Sentry.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add Sentry
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index bf01892c248b988531d21d9fb0f74d0adf2205ac..f499b87fcecc01078e1316850d5edf9b8a6c5360 100644
+index 04853c43b99951bf0d4c96ef73724625bdaf018f..1961ce5188d69ab4db860de64cc1bde60c6e2289 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -51,6 +51,7 @@ dependencies {
@@ -14,8 +14,8 @@ index bf01892c248b988531d21d9fb0f74d0adf2205ac..f499b87fcecc01078e1316850d5edf9b
      api("org.slf4j:slf4j-api:$slf4jVersion")
 +    api("io.sentry:sentry:5.4.0") // Pufferfish
  
-     implementation("org.ow2.asm:asm:9.5")
-     implementation("org.ow2.asm:asm-commons:9.5")
+     implementation("org.ow2.asm:asm:9.7")
+     implementation("org.ow2.asm:asm-commons:9.7")
 diff --git a/src/main/java/gg/pufferfish/pufferfish/sentry/SentryContext.java b/src/main/java/gg/pufferfish/pufferfish/sentry/SentryContext.java
 new file mode 100644
 index 0000000000000000000000000000000000000000..10310fdd53de28efb8a8250f6d3b0c8eb08fb68a

--- a/patches/server/0001-Pufferfish-branding.patch
+++ b/patches/server/0001-Pufferfish-branding.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Pufferfish branding
 Update branding
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 241808d8619e17c0681f79acbbc98af5bf52dd89..78664796d181d1b42fe80f388159344fb649da48 100644
+index bcfe59b6efb628ee1e7f9d60667360d4d885fb6a..650ea18f91f6c95d9d9b2032a5712b9a3a355244 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -13,8 +13,12 @@ configurations.named(log4jPlugins.compileClasspathConfigurationName) {
@@ -33,14 +33,11 @@ index 241808d8619e17c0681f79acbbc98af5bf52dd89..78664796d181d1b42fe80f388159344f
              "Implementation-Vendor" to date, // Paper
              "Specification-Title" to "Bukkit",
              "Specification-Version" to project.version,
-@@ -211,7 +215,5 @@ val runtimeClasspathForRunDev = sourceSets.main.flatMap { src ->
- }
+@@ -202,5 +206,4 @@ tasks.registerRunTask("runReobf") {
  tasks.registerRunTask("runDev") {
      description = "Spin up a non-relocated Mojang-mapped test server"
--    classpath(tasks.filterProjectDir.flatMap { it.outputJar })
--    classpath(runtimeClasspathForRunDev)
--    jvmArgs("-DPaper.isRunDev=true")
-+    classpath(sourceSets.main.map { it.runtimeClasspath })
+     classpath(sourceSets.main.map { it.runtimeClasspath })
+-    jvmArgs("-DPaper.pushPaperAssetsRoot=true")
  }
 diff --git a/src/main/java/com/destroystokyo/paper/Metrics.java b/src/main/java/com/destroystokyo/paper/Metrics.java
 index 4b002e8b75d117b726b0de274a76d3596fce015b..692c962193cf9fcc6801fc93f3220bdc673d527b 100644
@@ -213,7 +210,7 @@ index 0000000000000000000000000000000000000000..893d8c0946ef71a0561221dd76bffff0
 +}
 \ No newline at end of file
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 93b661e9cb7743aeff7da3972942cb73049a5e4c..fe69bdfd0a2bd810dbb6c46d3a98cc1c700ccaf8 100644
+index c8772c773f9933ed1d1debfe707af4373c458152..eef669da1a25023f6dd6d9c92387bd00197f873c 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1865,7 +1865,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -239,10 +236,10 @@ index c490a29bcf7410bc54959ee71375605964379ed5..d3e948a7f314197851587d86defc9755
      private final String bukkitVersion = Versioning.getBukkitVersion();
      private final Logger logger = Logger.getLogger("Minecraft");
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 1324f05de8106032ce290e928cf106fb4f450517..0493e0cf3fac2d4e065118f60f1d7b19751b467f 100644
+index 3c7a771c48cc2732cc038ca11bb93ec5f8c2d667..94681c5d807019be5caf0b5d5156c0d670f45f8f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -497,7 +497,7 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -502,7 +502,7 @@ public final class CraftMagicNumbers implements UnsafeValues {
  
      @Override
      public com.destroystokyo.paper.util.VersionFetcher getVersionFetcher() {

--- a/patches/server/0016-Dynamic-Activation-of-Brain.patch
+++ b/patches/server/0016-Dynamic-Activation-of-Brain.patch
@@ -84,7 +84,7 @@ index 0b7a43b6f2ec9a69281ff38f9bef6e33878be3f8..bd3ca0af0f50b2bf1f1b95d4578c1b05
 +}
 \ No newline at end of file
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index d070591b9ed4d8da1c85b97dc969f7d14d1dea20..0918f798f98a6cf9e50fe2f8609f579e3b096266 100644
+index 0c079381516d68a2d13d5a254a3b232c2a5e3d03..bf1262e00b5101630b636413b2e813d09c74cb1c 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -894,6 +894,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -96,7 +96,7 @@ index d070591b9ed4d8da1c85b97dc969f7d14d1dea20..0918f798f98a6cf9e50fe2f8609f579e
                      if (false && this.shouldDiscardEntity(entity)) { // CraftBukkit - We prevent spawning in general, so this butchering is not needed
                          entity.discard();
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index b2b28a8a486e182c7853b27ff5d5dfd896f24c4f..f974ef82e58378d9d50d56c1877a06f1574315ae 100644
+index 8aa9a0503e22ebe395d2d00049dfa1833f0d9349..fd09ba5cae3923f61b6bee8c1a0f9dc23ae7a6ed 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -424,6 +424,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, S
@@ -359,7 +359,7 @@ index 24044795d8e0f1fb15a4f2f5401f44897092f2a3..96ca567af2d8fb2ba39f995be80b9353
          if (this.assignProfessionWhenSpawned) {
              this.assignProfessionWhenSpawned = false;
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index c39894e824334f1dc52e0466cf9d84f7e219be70..bdc75da69ce2eb42ab1926ae877d6446668fd66c 100644
+index 3283ed99c35ffed6805567705e0518d9f84feedc..e69f8a8e3331989fef92fa331fbbe9b0af955f77 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
 @@ -38,6 +38,10 @@ import co.aikar.timings.MinecraftTimings;
@@ -373,7 +373,7 @@ index c39894e824334f1dc52e0466cf9d84f7e219be70..bdc75da69ce2eb42ab1926ae877d6446
  
  public class ActivationRange
  {
-@@ -221,6 +225,25 @@ public class ActivationRange
+@@ -223,6 +227,25 @@ public class ActivationRange
                  }
                  // Paper end - Configurable marker ticking
                  ActivationRange.activateEntity(entity);
@@ -399,7 +399,7 @@ index c39894e824334f1dc52e0466cf9d84f7e219be70..bdc75da69ce2eb42ab1926ae877d6446
              }
              // Paper end
          }
-@@ -237,12 +260,12 @@ public class ActivationRange
+@@ -239,12 +262,12 @@ public class ActivationRange
          if ( MinecraftServer.currentTick > entity.activatedTick )
          {
              if ( entity.defaultActivationState )

--- a/patches/server/0023-Cache-climbing-check-for-activation.patch
+++ b/patches/server/0023-Cache-climbing-check-for-activation.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Cache climbing check for activation
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 1f829dd574bed183b589284b42fd2e2e4e1e883f..25e30408c964b5257f1cf945892bd668df38252b 100644
+index 7d1bac1dcd03a64a9c3317b424fa248e5be471da..366121188c5abb550ed0a5f99d25c001628685bb 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -143,7 +143,6 @@ import org.bukkit.event.entity.EntityTeleportEvent;
@@ -38,10 +38,10 @@ index 1f829dd574bed183b589284b42fd2e2e4e1e883f..25e30408c964b5257f1cf945892bd668
          if (this.isSpectator()) {
              return false;
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index bdc75da69ce2eb42ab1926ae877d6446668fd66c..41cddf7e42f0e8f80973e482a95e55d3bd19f659 100644
+index e69f8a8e3331989fef92fa331fbbe9b0af955f77..d7c7e12c0b8f77e59d94de130972f762ed227726 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
-@@ -319,7 +319,7 @@ public class ActivationRange
+@@ -321,7 +321,7 @@ public class ActivationRange
          if ( entity instanceof LivingEntity )
          {
              LivingEntity living = (LivingEntity) entity;


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly

Paper Changes:
PaperMC/Paper@00fd87a Return dummy string instead of empty optional
PaperMC/Paper@710dced [ci skip] move custom brig exception to paper package
PaperMC/Paper@45d1486 build: Update paperweight to 1.5.12 and Gradle Wrapper to 8.7 (#10361)
PaperMC/Paper@e709245 Add config option for tripwire disarming fix
PaperMC/Paper@a203544 build: Compile against and shade the filtered jar (#9747)
PaperMC/Paper@bd38e03 Updated Upstream (Bukkit/CraftBukkit) (#10379)
PaperMC/Paper@a774fba feat: Entity#teleportAsync method with TeleportFlags (#10371)
PaperMC/Paper@06361fa Fix invalid block entities created during world gen (#10375)
PaperMC/Paper@bbee11f Deprecate Bukkit#getLogger (#10388)
PaperMC/Paper@d8456ee Don't throw NPE for unplaced blockstate on #getDrops (#10366)
PaperMC/Paper@182e79b Add more item use API (#10304)
PaperMC/Paper@acf838f Backport some stuff from the generators branch (#10365)
PaperMC/Paper@3d31e45 Add BlockBreakProgressUpdateEvent (#10300)
PaperMC/Paper@8e75001 Disable vertical air friction when item entities have friction disabled (#10369)
PaperMC/Paper@241d8e2 Ignore minecart in activation range (#10359)
PaperMC/Paper@1207162 Allow player-list API to self un/list (#10358)
PaperMC/Paper@5436d44 Deprecate several Keyed#getKey methods (#10357)