### PR TITLE
feat: Improve flare config retrieval

### DIFF
--- a/pufferfish-server/build.gradle.kts.patch
+++ b/pufferfish-server/build.gradle.kts.patch
@@ -50,12 +50,11 @@
      implementation("ca.spottedleaf:concurrentutil:0.0.3")
      implementation("org.jline:jline-terminal-ffm:3.27.1") // use ffm on java 22+
      implementation("org.jline:jline-terminal-jni:3.27.1") // fall back to jni on java 21
-@@ -165,6 +_,14 @@
+@@ -165,6 +_,13 @@
          isTransitive = false // includes junit
      }
  
 +    // Pufferfish start - config
-+    implementation("org.yaml:snakeyaml:1.32")
 +    implementation ("me.carleslc.Simple-YAML:Simple-Yaml:1.8.4") {
 +        exclude(group="org.yaml", module="snakeyaml")
 +    }

--- a/pufferfish-server/paper-patches/features/0001-Pufferfish-branding.patch
+++ b/pufferfish-server/paper-patches/features/0001-Pufferfish-branding.patch
@@ -58,6 +58,42 @@ index a7d1a959af6a810c0ce6d5baa08e4429e14d4f5b..5eabba2aeb754bd0ae46ddc2c3eed1aa
      private CompletableFuture<ComputedVersion> computedVersion = CompletableFuture.completedFuture(new ComputedVersion(Component.empty(), -1)); // Precompute-- someday move that stuff out of bukkit
  
      public static LiteralCommandNode<CommandSourceStack> create() {
+diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
+index 7675acdca2162e403f4ff523bcdd6efe0cb42d49..32129b7268171a0fc0f06bbf18c3c84f3169f1aa 100644
+--- a/src/main/java/org/bukkit/craftbukkit/Main.java
++++ b/src/main/java/org/bukkit/craftbukkit/Main.java
+@@ -17,6 +17,7 @@ public class Main {
+     public static final java.time.Instant BOOT_TIME = java.time.Instant.now(); // Paper - track initial start time
+     public static boolean useJline = true;
+     public static boolean useConsole = true;
++    public static OptionSet options = null; // Pufferfish - moved up for ServerConfigurations
+ 
+     // Paper start - Reset loggers after shutdown
+     static {
+@@ -158,6 +159,14 @@ public class Main {
+                         .defaultsTo(new File("paper.yml"))
+                         .describedAs("Yml file");
+ 
++                // Pufferfish start - Add the pufferfish config
++                this.acceptsAll(asList("pufferfish", "pufferfish-settings"), "File for Pufferfish settings")
++                        .withRequiredArg()
++                        .ofType(File.class)
++                        .defaultsTo(new File("pufferfish.yml"))
++                        .describedAs("Yml file");
++                // Pufferfish end - Add the pufferfish config
++
+                 this.acceptsAll(asList("add-plugin", "add-extra-plugin-jar"), "Specify paths to extra plugin jars to be loaded in addition to those in the plugins folder. This argument can be specified multiple times, once for each extra plugin jar path.")
+                         .withRequiredArg()
+                         .ofType(File.class)
+@@ -172,7 +181,7 @@ public class Main {
+             }
+         };
+ 
+-        OptionSet options = null;
++        //OptionSet options = null;
+ 
+         try {
+             options = parser.parse(args);
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 index c1aad9203af20102e560571435dfa75150b37c1b..3d1ac30dee0bc9639b7ee994923ace6f2973bbb3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java

--- a/pufferfish-server/src/main/java/gg/pufferfish/pufferfish/PufferfishConfig.java
+++ b/pufferfish-server/src/main/java/gg/pufferfish/pufferfish/PufferfishConfig.java
@@ -22,6 +22,7 @@ import org.simpleyaml.configuration.comments.CommentType;
 import org.simpleyaml.configuration.file.YamlFile;
 import org.simpleyaml.exceptions.InvalidConfigurationException;
 import org.bukkit.command.SimpleCommandMap;
+import gg.pufferfish.pufferfish.compat.ServerConfigurations;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -55,7 +56,7 @@ public class PufferfishConfig {
 	}
 	
 	public static void load() throws IOException {
-		File configFile = new File("pufferfish.yml");
+		final File configFile = ServerConfigurations.pufferfishConfig;
 		
 		if (configFile.exists()) {
 			try {

--- a/pufferfish-server/src/main/java/gg/pufferfish/pufferfish/compat/ServerConfigurations.java
+++ b/pufferfish-server/src/main/java/gg/pufferfish/pufferfish/compat/ServerConfigurations.java
@@ -1,6 +1,5 @@
 package gg.pufferfish.pufferfish.compat;
 
-import co.aikar.timings.TimingsManager;
 import com.google.common.io.Files;
 import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -9,46 +8,104 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.ArrayList;
 import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
+import java.util.regex.Pattern;
+import net.minecraft.server.MinecraftServer;
+import joptsimple.OptionSet;
+import net.minecraft.server.level.ServerLevel;
 
 public class ServerConfigurations {
 
-    public static final String[] configurationFiles = new String[]{
-      "server.properties",
-      "bukkit.yml",
-      "spigot.yml",
-      // "paper.yml", // TODO: Figure out what to do with this.
-      "pufferfish.yml"
-    };
+    private static final OptionSet options = org.bukkit.craftbukkit.Main.options;
+
+    private static final File properties = (File) options.valueOf("config");
+    private static final File bukkitConfig = (File) options.valueOf("bukkit-settings");
+    private static final File spigotConfig = (File) options.valueOf("spigot-settings");
+    private static final File paperConfigDir = (File) options.valueOf("paper-dir");
+    public static final File pufferfishConfig = (File) options.valueOf("pufferfish-settings"); // public so we can access it from the config class without repeated logic
+
+    private static final MinecraftServer server = MinecraftServer.getServer();
+    private static final List<ServerLevel> levelList = new ArrayList<>();
+
+    public static final List<String> configurationFiles = List.of(
+            properties.getPath(),
+            bukkitConfig.getPath(),
+            spigotConfig.getPath(),
+            paperConfigDir.getPath() + "/paper-global.yml",
+            paperConfigDir.getPath() + "/paper-world-defaults.yml",
+            pufferfishConfig.getPath()
+    );
+
+    private static final Map<String, String> configFiles = new HashMap<>(configurationFiles.size());
+
+    public static final List<String> hiddenConfigs = List.of(
+            "proxies.velocity.secret",
+            "web-services.token",
+            "misc.sentry-dsn",
+            "database",
+            "server-ip",
+            "motd",
+            "resource-pack",
+            "level-seed",
+            "rcon.password",
+            "rcon.ip",
+            "feature-seeds",
+            "world-settings.*.feature-seeds",
+            "world-settings.*.seed-*",
+            "seed-*"
+    );
+
+    private static final List<Pattern> regexPatterns = hiddenConfigs.stream()
+            .map(s -> Pattern.compile(s.replace(".", "\\.").replace("*", ".*")))
+            .collect(Collectors.toList());
 
     public static Map<String, String> getCleanCopies() throws IOException {
-        Map<String, String> files = new HashMap<>(configurationFiles.length);
-        for (String file : configurationFiles) {
-            files.put(file, getCleanCopy(file));
+        for (final String file : configurationFiles) {
+            if (configFiles.containsKey(file)) continue;
+            configFiles.put(file, getCleanCopy(file));
         }
-        return files;
+
+        for (final ServerLevel serverLevel : server.getAllLevels()) {
+            if (levelList.contains(serverLevel)) continue;
+            final File worldDir = serverLevel.getWorld().getWorldFolder();
+            final String paperWorldConfig = new File(worldDir, "paper-world.yml").getPath();
+            final String cleanConfig = getCleanCopy(paperWorldConfig);
+            levelList.add(serverLevel);
+            if (!cleanConfig.isEmpty()) {
+                configFiles.put(paperWorldConfig, cleanConfig);
+            }
+        }
+        return configFiles;
+    }
+
+    public static boolean matchesRegex(String key) {
+        for (final Pattern pattern : regexPatterns) {
+            if (pattern.matcher(key).matches()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public static String getCleanCopy(String configName) throws IOException {
-        File file = new File(configName);
-        List<String> hiddenConfigs = TimingsManager.hiddenConfigs;
+        final File file = new File(configName);
 
         switch (Files.getFileExtension(configName)) {
             case "properties": {
-                Properties properties = new Properties();
-                try (FileInputStream inputStream = new FileInputStream(file)) {
+                final Properties properties = new Properties();
+                try (final FileInputStream inputStream = new FileInputStream(file)) {
                     properties.load(inputStream);
                 }
-                for (String hiddenConfig : hiddenConfigs) {
-                    properties.remove(hiddenConfig);
+                for (final String hiddenConfig : properties.stringPropertyNames()) {
+                    if (matchesRegex(hiddenConfig)) properties.remove(hiddenConfig);
                 }
-                ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+                final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
                 properties.store(outputStream, "");
                 return Arrays.stream(outputStream.toString()
                   .split("\n"))
@@ -56,19 +113,24 @@ public class ServerConfigurations {
                   .collect(Collectors.joining("\n"));
             }
             case "yml": {
-                YamlConfiguration configuration = new YamlConfiguration();
+                final YamlConfiguration configuration = new YamlConfiguration();
                 try {
                     configuration.load(file);
-                } catch (InvalidConfigurationException e) {
+                } catch (final InvalidConfigurationException e) {
                     throw new IOException(e);
                 }
                 configuration.options().header(null);
-                for (String key : configuration.getKeys(true)) {
-                    if (hiddenConfigs.contains(key)) {
+
+                for (final String key : configuration.getKeys(true)) {
+                    if (matchesRegex(key)) {
                         configuration.set(key, null);
                     }
                 }
-                return configuration.saveToString();
+                if (configuration.getKeys(false).size() == 1) {
+                    return "";
+                } else {
+                    return configuration.saveToString();
+                }
             }
             default:
                 throw new IllegalArgumentException("Bad file type " + configName);


### PR DESCRIPTION
This PR fixes the todo in the ServerConfigurations class by adding automatic retrieval of per-world paper config files (and filtering them not to overwhelm the flare ui when the config is empty) and adds back the paper regular configs. It also addresses an Airplane issue where this class might have not retrieved all configs properly had their path been changed using the startup arguments.

Also added a flag argument for specifying a custom pufferfish config file and removes an useless dependency (its brought through the api module)

This implementation was taken from [Pufferfork](https://github.com/Toffikk/Pufferfork) and has been tested on a live flare server instance.

**this impl also caches the configs for subsequent flare runs not to waste time on unnecessary IO**