### PR TITLE
fix: prevent flare from crashing on unsupported envs

### DIFF
--- a/pufferfish-server/src/main/java/gg/pufferfish/pufferfish/flare/FlareSetup.java
+++ b/pufferfish-server/src/main/java/gg/pufferfish/pufferfish/flare/FlareSetup.java
@@ -4,14 +4,22 @@ import co.technove.flare.FlareInitializer;
 import co.technove.flare.internal.profiling.InitializationException;
 import net.minecraft.server.MinecraftServer;
 import org.apache.logging.log4j.Level;
+import java.util.Locale;
 
 public class FlareSetup {
 
+    private static final String OS_NAME = System.getProperty("os.name").toLowerCase(Locale.ROOT);
+    private static final String OS_ARCH = System.getProperty("os.arch").toLowerCase(Locale.ROOT);
     private static boolean initialized = false;
     private static boolean supported = false;
 
     public static void init() {
         if (initialized) {
+            return;
+        }
+
+        if (!OS_NAME.contains("linux") || !OS_ARCH.contains("amd64")) {
+            MinecraftServer.LOGGER.warn("Flare does not support running on {} {}, will not enable!", OS_NAME, OS_ARCH);
             return;
         }
 


### PR DESCRIPTION
previously this threw an exception
<img width="1123" height="394" alt="image" src="https://github.com/user-attachments/assets/f14cc947-1c7b-49ae-a58c-3a28b944ada7" />
